### PR TITLE
locked mysql2 version to 0.3.18 to avoid https://github.com/rails/rails/issues/21544

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 
 group :production do
   gem 'unicorn'
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
 end
 
 group :development, :test do


### PR DESCRIPTION
Locked mysql2 version in Gemfile to 0.3.18, otherwise deployment in OpsWorks fails with gem mysql2 0.4.1 as it hits bug https://github.com/rails/rails/issues/21544